### PR TITLE
Fix sidebar not visible on desktop

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import React, { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
 import Sidebar from './Sidebar';
 import TopBar from './TopBar';
 
@@ -9,6 +9,20 @@ interface LayoutProps {
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 1024) {
+        setSidebarOpen(true);
+      } else {
+        setSidebarOpen(false);
+      }
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-600 to-blue-400">


### PR DESCRIPTION
## Summary
- enable sidebar automatically on desktop widths

## Testing
- `npm run lint` *(fails: unexpected type warnings and unused vars)*
- `npm run build`
- `npm --prefix backend test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6877ba96e1288322b3f01c2d5b404407