### PR TITLE
Add PM2 config and production defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,11 @@ npm run dev
 
 **Opsi C: Gunakan PM2 (Keep Alive)**
 ```bash
-# Jalankan backend dengan PM2
-cd backend
-pm2 start ecosystem.config.js --env development
-
-# Jalankan frontend (build kemudian serve)
-cd ..
+# Build frontend terlebih dahulu
 npm run build
-pm2 serve dist 5173 --name frontend --spa
+
+# Jalankan keduanya dengan PM2
+pm2 start ecosystem.config.js
 ```
 
 ### 4. Akses Aplikasi
@@ -107,15 +104,17 @@ pm2 serve dist 5173 --name frontend --spa
 
 ## 🎮 Mode Demo vs Production
 
-### Mode Demo (Default - Siap Pakai)
-Aplikasi saat ini berjalan dalam **mode demo** dengan:
+### Mode Demo (Opsional)
+Secara bawaan aplikasi berjalan dalam **mode produksi**.
+Untuk mencoba antarmuka tanpa backend asli, Anda bisa mengaktifkan mode demo dengan mengatur `APP_MODE=demo` pada file `.env`.
+Mode demo menyediakan:
 - ✅ Mock data untuk semua fitur
 - ✅ Tidak memerlukan MongoDB
 - ✅ Tidak memerlukan Google OAuth setup
 - ✅ Siap pakai langsung untuk testing UI/UX
 - ✅ Login: admin/admin123
 
-Untuk beralih ke mode produksi, ubah variabel `APP_MODE` pada file `.env` menjadi `production`.
+
 
 ### Mode Production (Real Blogger Integration)
 Untuk menggunakan dengan Blogger API sesungguhnya:
@@ -357,11 +356,11 @@ npm run generate-token  # Generate OAuth token
    ```
 
 3. **PM2 Configuration**
-   
-   File `backend/ecosystem.config.js` sudah tersedia:
+
+   File `ecosystem.config.js` sudah tersedia di root project:
    ```bash
-   cd backend
-   pm2 start ecosystem.config.js --env production
+   npm run build
+   pm2 start ecosystem.config.js
    pm2 save
    pm2 startup
    ```
@@ -540,8 +539,8 @@ cd backend && npm run dev
 npm run dev
 
 # Untuk menjalankan terus-menerus gunakan PM2
-pm2 start backend/ecosystem.config.js --env development
-pm2 serve dist 5173 --name frontend --spa
+npm run build
+pm2 start ecosystem.config.js
 
 # 3. Access
 # Frontend: http://localhost:5173

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,8 +1,8 @@
 require('dotenv').config();
 
-// Default to demo mode if APP_MODE is not set
+// Default to production mode if APP_MODE is not set
 if (!process.env.APP_MODE) {
-  process.env.APP_MODE = 'demo';
+  process.env.APP_MODE = 'production';
 }
 const express = require('express');
 const cors = require('cors');

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  apps: [
+    {
+      name: 'blog-cms-backend',
+      cwd: 'backend',
+      script: 'server.js',
+      instances: 1,
+      env: {
+        NODE_ENV: 'production',
+        PORT: 3002,
+        APP_MODE: 'production'
+      }
+    },
+    {
+      name: 'blog-cms-frontend',
+      script: 'npm',
+      args: 'run preview -- --port 5173',
+      env: {
+        NODE_ENV: 'production'
+      }
+    }
+  ]
+};

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,10 +1,16 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import axios from 'axios';
 import Cookies from 'js-cookie';
 
+interface User {
+  id: string;
+  username: string;
+  email: string;
+}
+
 interface AuthContextType {
   isAuthenticated: boolean;
-  user: any;
+  user: User | null;
   login: (username: string, password: string) => Promise<boolean>;
   logout: () => void;
   loading: boolean;
@@ -14,14 +20,14 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const [user, setUser] = useState(null);
+  const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     checkAuthStatus();
-  }, []);
+  }, [checkAuthStatus]);
 
-  const checkAuthStatus = async () => {
+  const checkAuthStatus = useCallback(async () => {
     try {
       const token = Cookies.get('auth_token');
       if (token) {
@@ -36,7 +42,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   const login = async (username: string, password: string): Promise<boolean> => {
     try {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { FileText, File, MessageCircle, Eye, Users, TrendingUp } from 'lucide-react';
+import { FileText, File, MessageCircle, Eye } from 'lucide-react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 
 // Mock data

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
-import { Settings as SettingsIcon, Globe, User, Shield, RefreshCw, CheckCircle, AlertCircle } from 'lucide-react';
+import { Globe, User, Shield, RefreshCw, CheckCircle, AlertCircle, type LucideIcon } from 'lucide-react';
 import { useBlog } from '../contexts/BlogContext';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -9,7 +9,13 @@ const Settings: React.FC = () => {
   const { user } = useAuth();
   const [activeTab, setActiveTab] = useState<'blog' | 'oauth' | 'admin'>('blog');
 
-  const tabs = [
+  interface Tab {
+    id: 'blog' | 'oauth' | 'admin';
+    label: string;
+    icon: LucideIcon;
+  }
+
+  const tabs: Tab[] = [
     { id: 'blog', label: 'Blog Info', icon: Globe },
     { id: 'oauth', label: 'OAuth Status', icon: Shield },
     { id: 'admin', label: 'Admin', icon: User },
@@ -51,7 +57,7 @@ const Settings: React.FC = () => {
             return (
               <button
                 key={tab.id}
-                onClick={() => setActiveTab(tab.id as any)}
+                onClick={() => setActiveTab(tab.id)}
                 className={`flex items-center space-x-2 px-4 py-2 rounded-lg transition-all duration-200 ${
                   activeTab === tab.id
                     ? 'bg-purple-500/30 text-white'

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
-import { Calendar, TrendingUp, Eye, Users, BarChart3 } from 'lucide-react';
+import { Calendar, TrendingUp, Eye, Users, BarChart3, type LucideIcon } from 'lucide-react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, BarChart, Bar } from 'recharts';
 
 // Mock data
@@ -69,7 +69,13 @@ const Stats: React.FC = () => {
     }
   };
 
-  const tabs = [
+  interface Tab {
+    id: 'daily' | 'weekly' | 'monthly';
+    label: string;
+    icon: LucideIcon;
+  }
+
+  const tabs: Tab[] = [
     { id: 'daily', label: 'Harian', icon: Calendar },
     { id: 'weekly', label: 'Mingguan', icon: BarChart3 },
     { id: 'monthly', label: 'Bulanan', icon: TrendingUp },
@@ -100,7 +106,7 @@ const Stats: React.FC = () => {
             return (
               <button
                 key={tab.id}
-                onClick={() => setActiveTab(tab.id as any)}
+                onClick={() => setActiveTab(tab.id)}
                 className={`flex items-center space-x-2 px-4 py-2 rounded-lg transition-all duration-200 ${
                   activeTab === tab.id
                     ? 'bg-purple-500/30 text-white'


### PR DESCRIPTION
## Summary
- update AuthContext typing and hooks
- remove unused icons and fix types in pages
- default backend APP_MODE to production
- add project-wide PM2 ecosystem file
- document PM2 usage and production default in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68786d2326788322aad14254d618edf0